### PR TITLE
Remove deprecation and add missing flow annotations

### DIFF
--- a/app/src/main/java/com/manuelvicnt/coroutinesflow/AppGraph.kt
+++ b/app/src/main/java/com/manuelvicnt/coroutinesflow/AppGraph.kt
@@ -27,8 +27,10 @@ import com.manuelvicnt.coroutinesflow.main.MainViewModel
 import com.manuelvicnt.coroutinesflow.user.impl.UserRepository
 import com.manuelvicnt.coroutinesflow.user.UserViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.FlowPreview
 import java.lang.IllegalStateException
 
+@FlowPreview
 @ExperimentalCoroutinesApi
 object AppDIGraph {
     val coldFibonacciProducer by lazy { ColdFibonacciProducer() }
@@ -36,6 +38,7 @@ object AppDIGraph {
     val userRepository by lazy { UserRepository() }
 }
 
+@FlowPreview
 @ExperimentalCoroutinesApi
 object ViewModelFactory : ViewModelProvider.Factory {
 

--- a/app/src/main/java/com/manuelvicnt/coroutinesflow/fibonacci/impl/NeverEndingFibonacciProducer.kt
+++ b/app/src/main/java/com/manuelvicnt/coroutinesflow/fibonacci/impl/NeverEndingFibonacciProducer.kt
@@ -20,10 +20,10 @@ import androidx.annotation.VisibleForTesting
 import com.manuelvicnt.coroutinesflow.fibonacci.NeverEndingFibonacci
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.ConflatedBroadcastChannel
-import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.asFlow
 
+@FlowPreview
 @ExperimentalCoroutinesApi
 class NeverEndingFibonacciProducer : NeverEndingFibonacci {
 

--- a/app/src/main/java/com/manuelvicnt/coroutinesflow/main/MainActivity.kt
+++ b/app/src/main/java/com/manuelvicnt/coroutinesflow/main/MainActivity.kt
@@ -28,8 +28,10 @@ import com.manuelvicnt.coroutinesflow.R
 import com.manuelvicnt.coroutinesflow.ViewModelFactory
 import com.manuelvicnt.coroutinesflow.user.UserActivity
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.collect
 
+@FlowPreview
 @ExperimentalCoroutinesApi
 class MainActivity : AppCompatActivity() {
 

--- a/app/src/main/java/com/manuelvicnt/coroutinesflow/user/UserActivity.kt
+++ b/app/src/main/java/com/manuelvicnt/coroutinesflow/user/UserActivity.kt
@@ -24,7 +24,9 @@ import androidx.lifecycle.lifecycleScope
 import com.manuelvicnt.coroutinesflow.R
 import com.manuelvicnt.coroutinesflow.ViewModelFactory
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.FlowPreview
 
+@FlowPreview
 @ExperimentalCoroutinesApi
 class UserActivity : AppCompatActivity() {
 


### PR DESCRIPTION
### Objective
* Adds the `@FlowPreview` annotation to the places where the this preview API is used.
~Uses `ViewModelProvider` constructor instead of the deprecated `ViewModelProviders.of`~ (already done by someone else)


